### PR TITLE
shm_logger/src/named_semaphore.cc[5]: updated include path for named semaphore

### DIFF
--- a/shm_logger/src/named_semaphore.cc
+++ b/shm_logger/src/named_semaphore.cc
@@ -2,7 +2,7 @@
 //
 
 
-#include <wrappers/inc/named_semaphore.h>
+#include <shm_logger/inc/named_semaphore.h>
 
 namespace wrappers {
 


### PR DESCRIPTION
Going through shm_logger, doing commands myself and `make` returns:
```
wihobbs@cocsce-l3d22-05 ~/csce311/shm_logger $ make
g++ -MT .o/writer.o -MD -MP -MF .d/writer.Td -std=c++17 -g -Wall -Wextra -pedantic -I .. -c -o .o/writer.o src/writer.cc
g++ -MT .o/consumer.o -MD -MP -MF .d/consumer.Td -std=c++17 -g -Wall -Wextra -pedantic -I .. -c -o .o/consumer.o src/consumer.cc
g++ -MT .o/named_semaphore.o -MD -MP -MF .d/named_semaphore.Td -std=c++17 -g -Wall -Wextra -pedantic -I .. -c -o .o/named_semaphore.o src/named_semaphore.cc
src/named_semaphore.cc:5:10: fatal error: wrappers/inc/named_semaphore.h: No such file or directory
 #include <wrappers/inc/named_semaphore.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
makefile:65: recipe for target '.o/named_semaphore.o' failed
make: *** [.o/named_semaphore.o] Error 1
```

I assume this was due to an include path error, so I updated it in this commit. After this, make works fine. Am I wrong here? Is there a wrapper folder that we should be using?